### PR TITLE
Add Laravel backend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ Este comando compilará la aplicación en la carpeta `build`.
 
 Actualmente la exportación a Excel y PDF solo muestra alertas simuladas. Para utilizar la aplicación en producción debería integrarse un backend real y la funcionalidad de exportación.
 
+
+## Backend (Laravel + MariaDB)
+
+En la carpeta [`backend`](backend/) se incluyen las instrucciones para poner en marcha una API basada en **Laravel** que almacena los datos en **MariaDB**. De forma resumida:
+
+1. Instala PHP \(>=8.1\), Composer y MariaDB.
+2. Crea el proyecto dentro de la carpeta `backend` siguiendo la guía de [`backend/README.md`](backend/README.md).
+3. Configura las credenciales de base de datos en el archivo `.env` de Laravel.
+4. Ejecuta las migraciones con `php artisan migrate` y levanta el servidor con `php artisan serve`.
+
+La aplicación React consumirá estos endpoints, reemplazando los datos de ejemplo actualmente almacenados en `src/mock`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,36 @@
+# Backend en Laravel
+
+Este directorio está destinado a contener la API del proyecto utilizando **Laravel** y **MariaDB**.
+
+## Requisitos
+- PHP 8.1 o superior
+- Composer
+- MariaDB
+
+## Pasos iniciales
+
+1. Crear el proyecto:
+   ```bash
+   composer create-project laravel/laravel backend-api
+   cd backend-api
+   ```
+2. Copiar el archivo `.env.example` a `.env` y configurar las variables de conexión a MariaDB:
+   ```env
+   DB_CONNECTION=mysql
+   DB_HOST=127.0.0.1
+   DB_PORT=3306
+   DB_DATABASE=fichaplus
+   DB_USERNAME=usuario
+   DB_PASSWORD=clave
+   ```
+3. Ejecutar las migraciones de ejemplo:
+   ```bash
+   php artisan migrate
+   ```
+
+## Estructura sugerida
+- `app/Models` para los modelos de Eloquent (por ejemplo, `Cliente`, `Documento`).
+- `database/migrations` donde se definen las tablas.
+- `routes/api.php` para exponer endpoints que consumirá React.
+
+Consulta la [documentación oficial de Laravel](https://laravel.com/docs) para más detalles sobre cada comando y configuración.


### PR DESCRIPTION
## Summary
- document Laravel backend setup with MariaDB
- reference backend instructions in the main README

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685719cfb6d0832188aea29792e6d37c